### PR TITLE
Fix cancelOrder endpoint to use query parameters for orderId

### DIFF
--- a/src/controllers/customer.controller.js
+++ b/src/controllers/customer.controller.js
@@ -840,7 +840,7 @@ const getCustomerOrderHistory = asyncHandler(async (req, res) => {
 
 const cancelOrder = asyncHandler(async (req, res) => {
   const customerId = req.customer.id;
-  const { orderId } = req.body;
+  const { orderId } = req.query;
 
   if (
     !checkRequiredFields(


### PR DESCRIPTION
<!-- READ ME FIRST: Please fill in the explanation section below and check off every point from the Essential Checklist! -->

## Explanation

<!--
  - Explain what your PR does. If this PR fixes an existing bug, please include
  - "Fixes #bugnum:" in the explanation so that GitHub can auto-close the issue
  - when this PR is merged.
  -->

## Essential Checklist

<!-- Please tick the relevant boxes by putting an "x" in them. -->

- [x] The PR title and explanation each start with "Fix #bugnum: " (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] The PR does not contain any unnecessary code changes from code editor.
- [x] The PR is made from a branch that's **not** called "master" and is up-to-date with "master".
- [x] The PR is **assigned** to the appropriate reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated order cancellation mechanism to correctly retrieve order ID from query parameters instead of request body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->